### PR TITLE
When generating config from context, respect default working directory

### DIFF
--- a/src/ru/artyushov/jmhPlugin/configuration/JmhClassConfigurationProducer.java
+++ b/src/ru/artyushov/jmhPlugin/configuration/JmhClassConfigurationProducer.java
@@ -33,7 +33,9 @@ public class JmhClassConfigurationProducer extends JmhConfigurationProducer {
         final Module originalModule = configuration.getConfigurationModule().getModule();
         configuration.restoreOriginalModule(originalModule);
         configuration.setProgramParameters(benchmarkClass.getQualifiedName() + ".*");
-        configuration.setWorkingDirectory(PathUtil.getLocalPath(context.getProject().getBaseDir()));
+        if (configuration.getWorkingDirectory() == null) {  // respect default working directory if set
+            configuration.setWorkingDirectory(PathUtil.getLocalPath(context.getProject().getBaseDir()));
+        }
         configuration.setName(benchmarkClass.getName());
         configuration.setType(JmhConfiguration.Type.CLASS);
         return true;


### PR DESCRIPTION
Behavior before this change: Default working directory is set for JMH run configurations. Right click on a jmh class and run it, the generated run configuration does not inherit the default working directory. Instead it will always be set to the project base dir.

Behavior after this change: The generated run configuration will inherit the default working directory if it's set. Otherwise it uses the project base dir.

@artyushov Not sure if this actually fixes #5 -- reading it again I realized that you might mean something else by "default run parameters" -- but nevertheless I think this is a good fix. I've test this locally and it works as expected. Do you think that's sufficient?