### PR TITLE
append default parameters from default jmh configuration

### DIFF
--- a/src/ru/artyushov/jmhPlugin/configuration/JmhClassConfigurationProducer.java
+++ b/src/ru/artyushov/jmhPlugin/configuration/JmhClassConfigurationProducer.java
@@ -32,7 +32,8 @@ public class JmhClassConfigurationProducer extends JmhConfigurationProducer {
         setupConfigurationModule(context, configuration);
         final Module originalModule = configuration.getConfigurationModule().getModule();
         configuration.restoreOriginalModule(originalModule);
-        configuration.setProgramParameters(benchmarkClass.getQualifiedName() + ".*");
+        configuration.setProgramParameters(
+                createProgramParameters(benchmarkClass.getQualifiedName() + ".*", configuration.getProgramParameters()));
         configuration.setWorkingDirectory(PathUtil.getLocalPath(context.getProject().getBaseDir()));
         configuration.setName(benchmarkClass.getName());
         configuration.setType(JmhConfiguration.Type.CLASS);

--- a/src/ru/artyushov/jmhPlugin/configuration/JmhConfigurationProducer.java
+++ b/src/ru/artyushov/jmhPlugin/configuration/JmhConfigurationProducer.java
@@ -31,4 +31,8 @@ public abstract class JmhConfigurationProducer extends JavaRunConfigurationProdu
 
     @Override
     public abstract boolean isConfigurationFromContext(JmhConfiguration jmhConfiguration, ConfigurationContext configurationContext);
+
+    String createProgramParameters(String generatedParams, String defaultParams) {
+        return generatedParams + " " + defaultParams;
+    }
 }

--- a/src/ru/artyushov/jmhPlugin/configuration/JmhConfigurationProducer.java
+++ b/src/ru/artyushov/jmhPlugin/configuration/JmhConfigurationProducer.java
@@ -33,6 +33,6 @@ public abstract class JmhConfigurationProducer extends JavaRunConfigurationProdu
     public abstract boolean isConfigurationFromContext(JmhConfiguration jmhConfiguration, ConfigurationContext configurationContext);
 
     String createProgramParameters(String generatedParams, String defaultParams) {
-        return generatedParams + " " + defaultParams;
+        return defaultParams != null ? generatedParams + " " + defaultParams : generatedParams;
     }
 }

--- a/src/ru/artyushov/jmhPlugin/configuration/JmhMethodConfigurationProducer.java
+++ b/src/ru/artyushov/jmhPlugin/configuration/JmhMethodConfigurationProducer.java
@@ -35,7 +35,8 @@ public class JmhMethodConfigurationProducer extends JmhConfigurationProducer {
         }
         configuration.setBenchmarkClass(containingClass.getQualifiedName());
         configuration.setType(JmhConfiguration.Type.METHOD);
-        configuration.setProgramParameters(containingClass.getQualifiedName() + "." + method.getName());
+        configuration.setProgramParameters(
+                createProgramParameters(containingClass.getQualifiedName() + "." + method.getName(), configuration.getProgramParameters()));
         configuration.setName(containingClass.getName() + "." + method.getName());
         configuration.setWorkingDirectory(PathUtil.getLocalPath(context.getProject().getBaseDir()));
         return true;


### PR DESCRIPTION
Append parameters from default run Jmh configuration. Should solve #5 at least partially. Until now, default program arguments was useless as they were replaced by plugin.