### PR TITLE
Add JVM args to JMH runtime configurations

### DIFF
--- a/src/ru/artyushov/jmhPlugin/configuration/JmhConfigurable.java
+++ b/src/ru/artyushov/jmhPlugin/configuration/JmhConfigurable.java
@@ -1,6 +1,6 @@
 package ru.artyushov.jmhPlugin.configuration;
 
-import com.intellij.execution.ui.CommonProgramParametersPanel;
+import com.intellij.execution.ui.CommonJavaParametersPanel;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.options.SettingsEditor;
 import org.jetbrains.annotations.NotNull;
@@ -16,11 +16,11 @@ public class JmhConfigurable extends SettingsEditor<JmhConfiguration> {
 
     private JPanel editor = new JPanel();
 
-    private final CommonProgramParametersPanel commonProgramParameters;
+    private final CommonJavaParametersPanel commonProgramParameters;
 
     public JmhConfigurable() {
         editor.setLayout(new BoxLayout(editor, BoxLayout.X_AXIS));
-        commonProgramParameters = new CommonProgramParametersPanel();
+        commonProgramParameters = new CommonJavaParametersPanel();
         editor.add(commonProgramParameters);
     }
 

--- a/src/ru/artyushov/jmhPlugin/configuration/JmhConfiguration.java
+++ b/src/ru/artyushov/jmhPlugin/configuration/JmhConfiguration.java
@@ -27,6 +27,12 @@ import java.util.Map;
 public class JmhConfiguration extends ModuleBasedConfiguration<JavaRunConfigurationModule>
         implements CommonJavaRunConfigurationParameters, CompatibilityAwareRunProfile {
 
+    public static final String ATTR_VM_PARAMETERS = "vm-parameters";
+    public static final String ATTR_PROGRAM_PARAMETERS = "program-parameters";
+    public static final String ATTR_WORKING_DIR = "working-dir";
+    public static final String ATTR_BENCHMARK_TYPE = "benchmark-type";
+    public static final String ATTR_BENCHMARK_CLASS = "benchmark-class";
+
     public enum Type {
         METHOD, CLASS
     }
@@ -178,17 +184,20 @@ public class JmhConfiguration extends ModuleBasedConfiguration<JavaRunConfigurat
     @Override
     public void writeExternal(Element element) throws WriteExternalException {
         super.writeExternal(element);
+        if (vmParameters != null) {
+            element.setAttribute(ATTR_VM_PARAMETERS, vmParameters);
+        }
         if (programParameters != null) {
-            element.setAttribute("program-parameters", programParameters);
+            element.setAttribute(ATTR_PROGRAM_PARAMETERS, programParameters);
         }
         if (workingDirectory != null) {
-            element.setAttribute("working-dir", workingDirectory);
+            element.setAttribute(ATTR_WORKING_DIR, workingDirectory);
         }
         if (type != null) {
-            element.setAttribute("benchmark-type", type.name());
+            element.setAttribute(ATTR_BENCHMARK_TYPE, type.name());
         }
         if (benchmarkClass != null) {
-            element.setAttribute("benchmark-class", benchmarkClass);
+            element.setAttribute(ATTR_BENCHMARK_CLASS, benchmarkClass);
         }
         writeModule(element);
     }
@@ -196,10 +205,11 @@ public class JmhConfiguration extends ModuleBasedConfiguration<JavaRunConfigurat
     @Override
     public void readExternal(Element element) throws InvalidDataException {
         super.readExternal(element);
-        setProgramParameters(element.getAttributeValue("program-parameters"));
-        setWorkingDirectory(element.getAttributeValue("working-dir"));
-        setBenchmarkClass(element.getAttributeValue("benchmark-class"));
-        String typeString = element.getAttributeValue("benchmark-type");
+        setVMParameters(element.getAttributeValue(ATTR_VM_PARAMETERS));
+        setProgramParameters(element.getAttributeValue(ATTR_PROGRAM_PARAMETERS));
+        setWorkingDirectory(element.getAttributeValue(ATTR_WORKING_DIR));
+        setBenchmarkClass(element.getAttributeValue(ATTR_BENCHMARK_CLASS));
+        String typeString = element.getAttributeValue(ATTR_BENCHMARK_TYPE);
         if (typeString != null) {
             setType(Type.valueOf(typeString));
         }


### PR DESCRIPTION
JVM arguments are required to further control behavior of JMH. This is indispensible under Windows where it is not possible to run a benchmark with an overly long classpath without specifying `-Djmh.separateClasspathJAR` (available from JMH 1.20)

Setting `jvmArgs` of the benchmark class does not work, because the JVM argument has to be set on the initial process.