### PR TITLE
Only inherit environment on Windows OS

### DIFF
--- a/src/ru/artyushov/jmhPlugin/configuration/JmhConfigurationType.java
+++ b/src/ru/artyushov/jmhPlugin/configuration/JmhConfigurationType.java
@@ -25,7 +25,7 @@ public class JmhConfigurationType extends SimpleConfigurationType {
     @Override
     public @NotNull RunConfiguration createTemplateConfiguration(@NotNull Project project) {
         JmhConfiguration configuration = new JmhConfiguration("jmh-configuration-name", project, this);
-        configuration.setPassParentEnvs(true);
+        configuration.setPassParentEnvs(System.getProperty("os.name").startsWith("Windows"));
         return configuration;
     }
 


### PR DESCRIPTION
Limit the impact of inherited environment variables to Windows systems.
This was/is a workaround for #19: non-Windows systems already properly
provide the path to the tmp directory.